### PR TITLE
Fix typscript error - 

### DIFF
--- a/packages/rest-hooks/src/restClient.ts
+++ b/packages/rest-hooks/src/restClient.ts
@@ -102,9 +102,6 @@ interface _RequestPreprocessorOptions {
 const _requestPreprocessor =
   (opts: _RequestPreprocessorOptions) =>
   (req: InternalAxiosRequestConfig<unknown>):  InternalAxiosRequestConfig<unknown> =>
-  // Now using InternalAxiosRequestConfig to remove tyscript error
-  // he InternalAxiosRequestConfig serves as a behind-the-scenes type for Axios internals, 
-  // enabling features like interceptors and maintaining type safety
 {
   const { verbose, getAccessToken } = opts
   const accessToken = getAccessToken()

--- a/packages/rest-hooks/src/restClient.ts
+++ b/packages/rest-hooks/src/restClient.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse, AxiosRequestConfig } from 'axios'
+import axios, { AxiosResponse, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
 
 import { assocPath, keys } from 'ramda'
 import { isNilOrEmpty, isNotObject, isString } from 'ramda-adjunct'
@@ -75,7 +75,6 @@ export const createRestClient = (
   // all clients use these middlewares
 
   restClient.axiosClient.interceptors.request.use(
-    // @ts-expect-error becaused TS is a pain in the ass
     _requestPreprocessor({
       verbose: !!clientConfig?.verbose,
       getAccessToken: clientConfig?.getAccessToken || (() => 'fakeApiToken'),
@@ -102,7 +101,7 @@ interface _RequestPreprocessorOptions {
 
 const _requestPreprocessor =
   (opts: _RequestPreprocessorOptions) =>
-  (req: AxiosRequestConfig): AxiosRequestConfig =>
+  (req: InternalAxiosRequestConfig<unknown>):  InternalAxiosRequestConfig<unknown> =>
 {
   const { verbose, getAccessToken } = opts
   const accessToken = getAccessToken()

--- a/packages/rest-hooks/src/restClient.ts
+++ b/packages/rest-hooks/src/restClient.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 
 import { assocPath, keys } from 'ramda'
 import { isNilOrEmpty, isNotObject, isString } from 'ramda-adjunct'
@@ -102,6 +102,9 @@ interface _RequestPreprocessorOptions {
 const _requestPreprocessor =
   (opts: _RequestPreprocessorOptions) =>
   (req: InternalAxiosRequestConfig<unknown>):  InternalAxiosRequestConfig<unknown> =>
+  // Now using InternalAxiosRequestConfig to remove tyscript error
+  // he InternalAxiosRequestConfig serves as a behind-the-scenes type for Axios internals, 
+  // enabling features like interceptors and maintaining type safety
 {
   const { verbose, getAccessToken } = opts
   const accessToken = getAccessToken()


### PR DESCRIPTION
## Description
- Resolve _requestPreprocessor() Typescript error

## Changes Made
- The `_requestPreprocessor` function now takes an argument of type InternalAxiosRequestConfig<any> and returns the same type.
- The `InternalAxiosRequestConfig` serves as a behind-the-scenes type for Axios internals, enabling features like interceptors and maintaining type safety

## Related Issues
- [Resolve _requestPreprocessor() Typescript error
 Issue](https://github.com/users/SteveAtSentosa/projects/8/views/1?filterQuery=&pane=issue&itemId=53099501)


## Screenshots (if applicable)
-N/A

## Checklist
- [x] I have reviewed my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or errors.
- [x] I have tested my changes thoroughly.

## Additional Notes
-N/A
