### PR TITLE
Remove 'ls dist' from build command

### DIFF
--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -29,7 +29,7 @@
     "ramda-adjunct": "^4.1.1"
   },
   "scripts": {
-    "build": "pnpm run clean && tsup && ls dist",
+    "build": "pnpm run clean && tsup",
     "clean": "rimraf ./dist && mkdir dist",
     "clean:all": "pnpm run clean && rimraf ./node_modules pnpm-lock.yaml"
   }


### PR DESCRIPTION
#Remove 'ls dist' from build command

## Description
This PR Removes 'ls dist' from build command as discussed on the #sentosa-menotrs channel

## Related Issue
<!-- If applicable, reference any related issue here -->

## Changes Proposed
- Remove 'ls dist' from build command in package.js 


## Testing
<!-- Describe the testing strategy employed for this PR -->
- Run `pnpm build` to run build command
- [x] Should not return any error

### Jest Tests
<!-- Provide details of the Jest tests added or modified -->

## Checklist
- [x] I have reviewed my own code
- [x] I have performed a self-review of my changes
- [x] I have added/updated relevant documentation (if necessary)
- [x] All tests pass locally
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)
