### PR TITLE
10-rest-client-patch-tests

### DIFF
--- a/packages/rest-hooks/tests/handlers.ts
+++ b/packages/rest-hooks/tests/handlers.ts
@@ -5,7 +5,7 @@ export const handlers = [
 
   // Generic get hanlder
   http.get('*/simple-get*', async ({ request, params, cookies }) => {
-    const rsp = await makeTestResponse(request, params, cookies, { message: 'get succesful' })
+    const rsp = await makeTestResponse(request, params, cookies, { simpleGet: 'data' })
     return HttpResponse.json(rsp)
   }),
 

--- a/packages/rest-hooks/tests/handlers.ts
+++ b/packages/rest-hooks/tests/handlers.ts
@@ -23,7 +23,7 @@ export const handlers = [
 
   // Generic patch handler
   http.patch('*/simple-patch*', async ({ request, params, cookies }) => {
-    const rsp = await makeTestResponse(request, params, cookies, { message: 'patch succesful' })
+    const rsp = await makeTestResponse(request, params, cookies, {  message: 'patch succesful',  })
     return HttpResponse.json(rsp)
   }),
 

--- a/packages/rest-hooks/tests/handlers.ts
+++ b/packages/rest-hooks/tests/handlers.ts
@@ -5,7 +5,7 @@ export const handlers = [
 
   // Generic get hanlder
   http.get('*/simple-get*', async ({ request, params, cookies }) => {
-    const rsp = await makeTestResponse(request, params, cookies, { simpleGet: 'data' })
+    const rsp = await makeTestResponse(request, params, cookies, { message: 'get succesful' })
     return HttpResponse.json(rsp)
   }),
 

--- a/packages/rest-hooks/tests/handlers.ts
+++ b/packages/rest-hooks/tests/handlers.ts
@@ -21,4 +21,10 @@ export const handlers = [
     return HttpResponse.json(rsp)
   }),
 
+  // Generic patch handler
+  http.patch('*/simple-patch*', async ({ request, params, cookies }) => {
+    const rsp = await makeTestResponse(request, params, cookies, { message: 'patch succesful' })
+    return HttpResponse.json(rsp)
+  }),
+
 ]

--- a/packages/rest-hooks/tests/restClient.test.ts
+++ b/packages/rest-hooks/tests/restClient.test.ts
@@ -353,8 +353,100 @@ describe('Test Rest Client', () => {
 
   })
 
-  test.skip('Test Straight Patch', async () => {})
-  test.skip('Test PatchFn', async () => {})
+  test('Test Straight Patch', async () => {
+    const restClient = createRestClient(
+      defaultClientConfig,    
+      defaultServerConfig
+    )
+    const patchData = { artist: 'Caligulas Horse' }
+    rsp = (await restClient.patch(
+      '/simple-patch/user/favorite-song',
+      patchData
+    )) as unknown as StcRestTest.TestResponse;
+
+    [requestInfo, responseBody] = rsp
+
+    expect(requestInfo?.url).toEqual(
+      'http://fakehost.com:5023/simple-patch/user/favorite-song'
+    )
+    expect(requestInfo?.method).toEqual('PATCH')
+    expect(requestInfo?.headers.authorization).toEqual(
+      'Bearer testing-access-token'
+    )
+    expect(requestInfo?.body).toEqual(patchData)
+    expect(responseBody).toEqual({ message: 'patch succesful' })
+
+  })
+
+  test('Test PatchFn', async () => {
+    const restClient = createRestClient({
+      ...defaultClientConfig,
+      getAccessToken: () => 'another-access-token'
+    }, defaultServerConfig)
+
+    // simple patch
+
+    const patchFn = restClient.createPatchFn('/simple-patch')
+    data = { artist: 'Enter Shikari' }
+    rsp = await patchFn({ data }) as unknown as StcRestTest.TestResponse;
+
+    [ requestInfo, responseBody ] = rsp
+
+    expect(requestInfo?.url).toEqual('http://fakehost.com:5023/simple-patch')
+    expect(requestInfo?.method).toEqual('PATCH')
+    expect(requestInfo?.headers.authorization).toEqual('Bearer another-access-token')
+    expect(requestInfo?.body).toEqual(data)
+    expect(responseBody).toEqual({ message: 'patch succesful' })
+
+    // with query params
+
+    data = { artist: 'Maria Cristina Plata' }
+    restParams = { queryParams: { genre: 'folk' } }
+    rsp = (await patchFn({ data, restParams })) as unknown as StcRestTest.TestResponse;
+
+    [requestInfo, responseBody] = rsp
+
+    expect(requestInfo?.url).toEqual(
+      'http://fakehost.com:5023/simple-patch?genre=folk')
+    expect(requestInfo?.method).toEqual('PATCH')
+    expect(requestInfo?.headers.authorization).toEqual('Bearer another-access-token')
+    expect(requestInfo?.body).toEqual(data)
+    expect(responseBody).toEqual({ message: 'patch succesful' })
+
+    // with path params
+
+    const patchFnWithPathParams = restClient.createPatchFn('/simple-patch/:genre')
+    data = { artist: 'Breaking Benjamin' }
+    const pathParams = { genre: 'metal' }
+
+    rsp = (await patchFnWithPathParams({ data, restParams: { pathParams } })) as unknown as StcRestTest.TestResponse;
+
+    [requestInfo, responseBody] = rsp
+
+    expect(requestInfo?.url).toEqual('http://fakehost.com:5023/simple-patch/metal')
+    expect(requestInfo?.method).toEqual('PATCH')
+    expect(requestInfo?.headers.authorization).toEqual('Bearer another-access-token')
+    expect(requestInfo?.body).toEqual(data)
+    expect(responseBody).toEqual({ message: 'patch succesful' })
+
+    // with query and path params
+
+    data = { artist: 'Esperanza Spalding' }
+    restParams = {
+      pathParams: { genre:'jazz' },
+      queryParams: { song: 'radio song' },
+    }
+
+    rsp = (await patchFnWithPathParams({ data, restParams })) as unknown as StcRestTest.TestResponse;
+
+    [requestInfo, responseBody] = rsp
+  
+    expect(requestInfo?.url).toEqual('http://fakehost.com:5023/simple-patch/jazz?song=radio%20song')
+    expect(requestInfo?.method).toEqual('PATCH')
+    expect(requestInfo?.headers.authorization).toEqual('Bearer another-access-token')
+    expect(requestInfo?.body).toEqual(data)
+    expect(responseBody).toEqual({ message: 'patch succesful' })
+  })
 
   test.skip('Test Straight Delete', async () => {})
   test.skip('Test DeleteFn', async () => {})

--- a/packages/rest-hooks/tests/testTypes.ts
+++ b/packages/rest-hooks/tests/testTypes.ts
@@ -1,4 +1,4 @@
-import { DefaultBodyType, StrictRequest, HttpResponse, PathParams } from 'msw';
+import { DefaultBodyType, StrictRequest, HttpResponse, PathParams } from 'msw'
 
 export namespace StcRestTest {
   export type Request<
@@ -10,8 +10,8 @@ export namespace StcRestTest {
 
     export type RequestUrl = string
     export type RequestMethod = string
-    export type ReqestPathParams = PathParams
-    export type ReqestCookies = Record<string, string>
+    export type RequestPathParams = PathParams
+    export type RequestCookies = Record<string, string>
     export interface RequestHeaders {[key: string]: string | string[]}
     export type RequestBody = any
 
@@ -19,8 +19,8 @@ export namespace StcRestTest {
       method: RequestMethod
       headers: RequestHeaders
       url: RequestUrl
-      pathParams: ReqestPathParams
-      cookies: ReqestCookies
+      pathParams: RequestPathParams
+      cookies: RequestCookies
       body: RequestBody
     } | null
 

--- a/packages/rest-hooks/tests/testTypes.ts
+++ b/packages/rest-hooks/tests/testTypes.ts
@@ -19,9 +19,9 @@ export namespace StcRestTest {
       method: RequestMethod
       headers: RequestHeaders
       url: RequestUrl
-      pathParams: RequestPathParams
-      cookies: RequestCookies
-      body: RequestBody
+      pathParams?: RequestPathParams
+      cookies?: RequestCookies
+      body?: RequestBody
     } | null
 
   export type TestResponse = [

--- a/packages/rest-hooks/tests/testUtils.ts
+++ b/packages/rest-hooks/tests/testUtils.ts
@@ -24,8 +24,8 @@ export const extractRequestHeaders = (request: StcRestTest.Request) => {
 
 export const makeTestResponse = async (
   request: StcRestTest.Request,
-  params: StcRestTest.ReqestPathParams,
-  cookies: StcRestTest.ReqestCookies,
+  params: StcRestTest.RequestPathParams,
+  cookies: StcRestTest.RequestCookies,
   data: any,
 ) : Promise<StcRestTest.TestResponse> => [
   {


### PR DESCRIPTION
Done with generic patch happy path testing.

TODO: 
 - Error test cases?
 - Suggested abstraction?
 
 Use this test handler inside the describe:
 ```
const assertResponse = (method: 'POST' | 'PUT' | 'GET' | 'PATCH' | 'DELETE', data: Record<string, unknown> ) => {
    expect(requestInfo?.url).toEqual(`http://fakehost.com:5023/simple-${method.toLowerCase()}`)
    expect(requestInfo?.method).toEqual(method)
    expect(requestInfo?.headers.authorization).toEqual('Bearer testing-access-token')
    expect(responseBody).toEqual(data)
}
 ```
  Example usage:
 ``` 
 assertResponse('GET', { simpleGet: 'data' })
 ```
  Instead of this:
 ```
    expect(requestInfo?.url).toEqual('http://fakehost.com:5023/simple-get')
    expect(requestInfo?.method).toEqual('GET')
    expect(requestInfo?.headers.authorization).toEqual('Bearer testing-access-token')
    expect(responseBody).toEqual({ simpleGet: 'data' })
```
 